### PR TITLE
Added variable support

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = function (editor, namespace) {
       }
 
       if (ed.text !== undefined && ed.text !== null) {
+        ed.text = ed.text.replace('{element}', elem.text() );
         elem.text(ed.text);
       }
 


### PR DESCRIPTION
user can now use the existing tag text in the text replacement, just add '{element}' in the text attribute when calling the plugin. @todo do the same for the attributes.
